### PR TITLE
Update Thaumcraft.zs and Enderio.zs

### DIFF
--- a/overrides/scripts/EnderIO.zs
+++ b/overrides/scripts/EnderIO.zs
@@ -271,7 +271,7 @@ scripts.process.crush(<enderio:item_material:76>, <enderio:block_holy_fog>, "exc
 scripts.process.alloy([<minecraft:glowstone_dust>, <minecraft:clay_ball>], <enderio:item_material:76> * 2, "except: alloySmelter");
 
 # Dark Steel Upgrade Recycling
-	mods.nuclearcraft.decay_hastener.addRecipe([<enderio:item_dark_steel_upgrade:1>.anyDamage(), <enderio:item_dark_steel_upgrade>, 2.0, 2.0]);
+	mods.nuclearcraft.DecayHastener.addRecipe([<enderio:item_dark_steel_upgrade:1>.anyDamage(), <enderio:item_dark_steel_upgrade>, 2.0, 2.0]);
 
 # Dark Steel Upgrade Expensive, Thermal
 	mods.thermalexpansion.InductionSmelter.addRecipe(<enderio:item_dark_steel_upgrade>, <enderio:block_alloy:6>, <minecraft:clay>, 25000);

--- a/overrides/scripts/EnderIO.zs
+++ b/overrides/scripts/EnderIO.zs
@@ -271,7 +271,7 @@ scripts.process.crush(<enderio:item_material:76>, <enderio:block_holy_fog>, "exc
 scripts.process.alloy([<minecraft:glowstone_dust>, <minecraft:clay_ball>], <enderio:item_material:76> * 2, "except: alloySmelter");
 
 # Dark Steel Upgrade Recycling
-	mods.nuclearcraft.DecayHastener.addRecipe([<enderio:item_dark_steel_upgrade:1>.anyDamage(), <enderio:item_dark_steel_upgrade>, 2.0, 2.0]);
+	mods.nuclearcraft.decay_hastener.addRecipe([<enderio:item_dark_steel_upgrade:1>.anyDamage(), <enderio:item_dark_steel_upgrade>, 2.0, 2.0]);
 
 # Dark Steel Upgrade Expensive, Thermal
 	mods.thermalexpansion.InductionSmelter.addRecipe(<enderio:item_dark_steel_upgrade>, <enderio:block_alloy:6>, <minecraft:clay>, 25000);

--- a/overrides/scripts/Thaumcraft.zs
+++ b/overrides/scripts/Thaumcraft.zs
@@ -50,6 +50,11 @@ mods.thaumcraft.SmeltingBonus.addSmeltingBonus(<ore:oreLead>, <thermalfoundation
 	[<ore:slabTreatedWood>, <ore:slabTreatedWood>, <ore:slabTreatedWood>],
 	[<ore:plankTreatedWood>, null, <ore:plankTreatedWood>]]);
 
+# Amber
+	recipe.remove(<thaumcraft:Amber>);
+	recipe.addShapeless("Amber", <thaumcraft:Amber> * 4, 
+	[<thaumcraft:amber_block>]);
+
 # Amber Bricks
 	recipes.remove(<thaumcraft:amber_brick>);
 	recipes.addShapeless("Thaumcraft Amber Brick", 


### PR DESCRIPTION
fix amber duping glitch by adding a recipe uncrafting amber blocks to 4 amber not 9 